### PR TITLE
fix: onIndexChanged will not call after AnchorScrollViewWrapper is up…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,5 @@
 
 ## 0.3.2
 
-* Fix [issue #2](https://github.com/lucian1024/anchor_scroll_controller/issues/2):  When the height of item is very large which leads to only one item is in the viewport, it will fall to infinite loop. 
+* Fix [issue #2](https://github.com/lucian1024/anchor_scroll_controller/issues/2):  When the height of item is very large which leads to only one item is in the viewport, it will fall to infinite loop.
+* Bugfix: `onIndexChanged` will not call after AnchorScrollViewWrapper is update.

--- a/example/lib/cascaded_scroll_controller.dart
+++ b/example/lib/cascaded_scroll_controller.dart
@@ -34,7 +34,7 @@ class _CascadesScrollControllerWidgetState extends State<CascadesScrollControlle
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
-          title: Text("GeneralScrollView"),
+          title: Text("CascadedScrollView"),
         ),
         body: Column(
           children: [

--- a/lib/anchor_scroll_wrapper.dart
+++ b/lib/anchor_scroll_wrapper.dart
@@ -86,21 +86,40 @@ class AnchorScrollViewWrapper extends InheritedWidget
 
   final IndexChanged? onIndexChanged;
 
+  VoidCallback? _scrollListener;
+
   static AnchorScrollViewWrapper? of(BuildContext context) {
     return context
         .dependOnInheritedWidgetOfExactType<AnchorScrollViewWrapper>();
   }
 
   @override
-  bool updateShouldNotify(AnchorScrollViewWrapper oldWidget) =>
-      controller != oldWidget.controller;
+  bool updateShouldNotify(AnchorScrollViewWrapper oldWidget) {
+    oldWidget.removeScrollListener();
+    addScrollListener();
+    return false;
+  }
 
   @override
   InheritedElement createElement() {
-    controller.addListener(() {
-      notifyIndexChanged(controller);
-    });
+    addScrollListener();
     return super.createElement();
+  }
+
+  void addScrollListener() {
+    if (_scrollListener == null) {
+      _scrollListener = () {
+        notifyIndexChanged(controller);
+      };
+      controller.addListener(_scrollListener!);
+    }
+  }
+
+  void removeScrollListener() {
+    if (_scrollListener == null) {
+      return;
+    }
+    controller.removeListener(_scrollListener!);
   }
 
   Future<void> scrollToIndex(


### PR DESCRIPTION
fix: onIndexChanged will not call after AnchorScrollViewWrapper is update.