### PR TITLE
fix an issue that `_currIndex` may be set incorrectly

### DIFF
--- a/lib/src/anchor_scroll_controller.dart
+++ b/lib/src/anchor_scroll_controller.dart
@@ -217,7 +217,6 @@ class AnchorScrollControllerHelper {
         scrollController.jumpTo(_applyAnchorOffset(targetScrollOffset));
       }
 
-      _currIndex = index;
       _isScrollingToIndex = false;
     }
   }


### PR DESCRIPTION
When `scrollToIndex()` is called to scroll to an item that isn't in viewport, the scrolling may stop at the top or bottom of the list because the target item hasn't been loaded. Then `_currIndex` will be set to the target index incorrectly. It may cause some notifications about index change to be ignored.
`notifyIndexChanged()` can set `_currIndex` to the correct index.